### PR TITLE
odometry publisher: fix spamming warning message TF_REPEATED_DATA

### DIFF
--- a/fuse_models/include/fuse_models/odometry_2d_publisher.h
+++ b/fuse_models/include/fuse_models/odometry_2d_publisher.h
@@ -202,6 +202,8 @@ protected:
 
   tf2_ros::TransformBroadcaster tf_broadcaster_;
 
+  ros::Time last_tf_broadcast_time_;
+
   std::unique_ptr<tf2_ros::TransformListener> tf_listener_;
 
   fuse_core::DelayedThrottleFilter delayed_throttle_filter_{ 10.0 };  //!< A ros::console filter to print delayed

--- a/fuse_models/include/fuse_models/odometry_3d_publisher.h
+++ b/fuse_models/include/fuse_models/odometry_3d_publisher.h
@@ -207,6 +207,8 @@ protected:
 
   tf2_ros::TransformBroadcaster tf_broadcaster_;
 
+  ros::Time last_tf_broadcast_time_;
+
   std::unique_ptr<tf2_ros::TransformListener> tf_listener_;
 
   fuse_core::DelayedThrottleFilter delayed_throttle_filter_{ 10.0 };  //!< A ros::console filter to print delayed

--- a/fuse_models/src/odometry_2d_publisher.cpp
+++ b/fuse_models/src/odometry_2d_publisher.cpp
@@ -469,7 +469,14 @@ void Odometry2DPublisher::publishTimerCallback(const ros::TimerEvent& event)
   odom_pub_.publish(odom_output);
   acceleration_pub_.publish(acceleration_output);
 
-  if (params_.publish_tf)
+  // Publish a tf if enabled and there is a different (practically said new) time
+  // Checking the time is important since otherwise at ROS 1 Noetic an internal warning messages spams the log (which
+  // cannot be disabled) and publishing a tf with the same time as before anyway is ignored.
+  // In practice if predict_to_current_time == true, this does not have an effect. If predict_to_current_time == false,
+  // then in case this check is not there and the publisher rate has a same/lower publishing rate than the optimizer
+  // frequency, the above issue appears.
+  // For more information see also: https://github.com/ros/geometry2/issues/467
+  if (params_.publish_tf && odom_output.header.stamp != last_tf_broadcast_time_)
   {
     auto frame_id = odom_output.header.frame_id;
     auto child_frame_id = odom_output.child_frame_id;
@@ -514,6 +521,7 @@ void Odometry2DPublisher::publishTimerCallback(const ros::TimerEvent& event)
     }
 
     tf_broadcaster_.sendTransform(trans);
+    last_tf_broadcast_time_ = trans.header.stamp;
   }
 }
 

--- a/fuse_models/src/odometry_3d_publisher.cpp
+++ b/fuse_models/src/odometry_3d_publisher.cpp
@@ -638,7 +638,14 @@ void Odometry3DPublisher::publishTimerCallback(const ros::TimerEvent& event)
   odom_pub_.publish(odom_output);
   acceleration_pub_.publish(acceleration_output);
 
-  if (params_.publish_tf)
+  // Publish a tf if enabled and there is a different (practically said new) time
+  // Checking the time is important since otherwise at ROS 1 Noetic an internal warning messages spams the log (which
+  // cannot be disabled) and publishing a tf with the same time as before anyway is ignored.
+  // In practice if predict_to_current_time == true, this does not have an effect. If predict_to_current_time == false,
+  // then in case this check is not there and the publisher rate has a same/lower publishing rate than the optimizer
+  // frequency, the above issue appears.
+  // For more information see also: https://github.com/ros/geometry2/issues/467
+  if (params_.publish_tf && odom_output.header.stamp != last_tf_broadcast_time_)
   {
     auto frame_id = odom_output.header.frame_id;
     auto child_frame_id = odom_output.child_frame_id;
@@ -680,6 +687,7 @@ void Odometry3DPublisher::publishTimerCallback(const ros::TimerEvent& event)
     }
 
     tf_broadcaster_.sendTransform(trans);
+    last_tf_broadcast_time_ = trans.header.stamp;
   }
 }
 


### PR DESCRIPTION
odometry publisher: fix spamming warning message TF_REPEATED_DATA from tf (which cannot be disabled because of internal direct stdout message) by publishing only tf if there is really a new one available (at ROS 1 noetic publishing the same time again anyway dropped the new content; generally see also https://github.com/ros/geometry2/issues/467)