### PR TITLE
add delta information publishing and bump fuse_models version to 1.3.5

### DIFF
--- a/fuse_models/CMakeLists.txt
+++ b/fuse_models/CMakeLists.txt
@@ -32,6 +32,7 @@ find_package(tf2_2d REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
 # find_package(mujoco REQUIRED)
+find_package(angles REQUIRED)
 
 find_package(Ceres REQUIRED)
 find_package(Eigen3 REQUIRED)
@@ -87,7 +88,8 @@ target_link_libraries(
   tf2::tf2
   tf2_2d::tf2_2d
   ${tf2_geometry_msgs_TARGETS}
-  tf2_ros::tf2_ros)
+  tf2_ros::tf2_ros
+  angles::angles)
 
 # ##############################################################################
 # Testing ##
@@ -134,6 +136,7 @@ ament_export_dependencies(
   tf2_2d
   tf2_geometry_msgs
   tf2_ros
+  angles
   Ceres
   Eigen3
   Boost)

--- a/fuse_models/include/fuse_models/odometry_2d_publisher.hpp
+++ b/fuse_models/include/fuse_models/odometry_2d_publisher.hpp
@@ -55,6 +55,7 @@
 #include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/float64.hpp>
 
 namespace fuse_models
 {
@@ -186,6 +187,14 @@ protected:
   void publishTimerCallback();
 
   /**
+   * @brief publish the given double value with the given publisher
+   * @param value to publish
+   * @param pub_to_use the publisher used to send the data
+   */
+  static void publishDouble(double value, const rclcpp::Publisher<std_msgs::msg::Float64>::SharedPtr& pub_to_use);
+
+
+  /**
    * @brief Object that searches for the most recent common timestamp for a set of variables
    */
   using Synchronizer = fuse_publishers::StampedVariableSynchronizer<
@@ -217,6 +226,10 @@ protected:
 
   rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr odom_pub_;
   rclcpp::Publisher<geometry_msgs::msg::AccelWithCovarianceStamped>::SharedPtr acceleration_pub_;
+
+  rclcpp::Publisher<std_msgs::msg::Float64>::SharedPtr delta_x_publisher_;
+  rclcpp::Publisher<std_msgs::msg::Float64>::SharedPtr delta_y_publisher_;
+  rclcpp::Publisher<std_msgs::msg::Float64>::SharedPtr delta_yaw_publisher_;
 
   std::shared_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_ = nullptr;
   std::unique_ptr<tf2_ros::TransformListener> tf_listener_;

--- a/fuse_models/include/fuse_models/parameters/odometry_2d_publisher_params.hpp
+++ b/fuse_models/include/fuse_models/parameters/odometry_2d_publisher_params.hpp
@@ -83,6 +83,9 @@ public:
         interfaces, fuse_core::joinParameterName(ns, "predict_with_acceleration"), predict_with_acceleration);
     publish_zero_when_stopped = fuse_core::getParam(
         interfaces, fuse_core::joinParameterName(ns, "publish_zero_when_stopped"), publish_zero_when_stopped);
+    publish_delta_information = fuse_core::getParam(
+      interfaces, fuse_core::joinParameterName(ns, "publish_delta_information"), publish_delta_information);
+
     publish_frequency =
         fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "publish_frequency"), publish_frequency);
 
@@ -133,7 +136,12 @@ public:
     topic = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "topic"), topic);
     acceleration_topic =
         fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "acceleration_topic"), acceleration_topic);
-
+    delta_x_topic =
+        fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "delta_x_topic"), delta_x_topic);
+    delta_y_topic =
+        fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "delta_y_topic"), delta_y_topic);
+    delta_yaw_topic =
+        fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "delta_yaw_topic"), delta_yaw_topic);
     fuse_core::loadCovarianceOptionsFromROS(interfaces, covariance_options, "covariance_options");
   }
 
@@ -147,6 +155,7 @@ public:
   bool predict_with_acceleration{ false };
   bool publish_zero_when_stopped{ false };  //!< Whether to publish a zero transformation after activating once and
                                             //!< deactivating afterwards
+  bool publish_delta_information{ false };  //!< Whether to publish deltas about pose correction
   double publish_frequency{ 10.0 };
   fuse_core::Matrix8d process_noise_covariance;  //!< Process noise covariance matrix
   bool scale_process_noise{ false };
@@ -164,6 +173,10 @@ public:
   std::string world_frame_id{ odom_frame_id };
   std::string topic{ "odometry/filtered" };
   std::string acceleration_topic{ "acceleration/filtered" };
+  std::string delta_x_topic{ "~/transformation/delta_x" };
+  std::string delta_y_topic{ "~/transformation/delta_y" };
+  std::string delta_yaw_topic{ "~/transformation/delta_yaw" };
+
   ceres::Covariance::Options covariance_options;
 };
 

--- a/fuse_models/package.xml
+++ b/fuse_models/package.xml
@@ -4,7 +4,7 @@
   schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>fuse_models</name>
-  <version>1.3.4</version>
+  <version>1.3.5</version>
   <description>fuse plugins that implement various kinematic and sensor models</description>
 
   <maintainer email="tmoore@locusrobotics.com">Tom Moore</maintainer>
@@ -36,6 +36,7 @@
   <build_depend>tf2_2d</build_depend>
   <build_depend>tf2_geometry_msgs</build_depend>
   <build_depend>tf2_ros</build_depend>
+  <build_depend>angles</build_depend>
 
   <exec_depend>covariance_geometry_ros</exec_depend>
   <exec_depend>fuse_constraints</exec_depend>
@@ -55,6 +56,7 @@
   <exec_depend>tf2_2d</exec_depend>
   <exec_depend>tf2_geometry_msgs</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
+  <exec_depend>angles</exec_depend>
 
   <test_depend>benchmark</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>

--- a/fuse_models/src/odometry_2d_publisher.cpp
+++ b/fuse_models/src/odometry_2d_publisher.cpp
@@ -53,6 +53,7 @@
 #include <pluginlib/class_list_macros.hpp>
 #include <tf2_2d/tf2_2d.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#include <angles/angles.h>
 
 // Register this publisher with ROS as a plugin.
 PLUGINLIB_EXPORT_CLASS(fuse_models::Odometry2DPublisher, fuse_core::Publisher)
@@ -88,7 +89,7 @@ void Odometry2DPublisher::onInit()
 
   params_.loadFromROS(interfaces_, name_);
 
-  if (!params_.invert_tf && params_.world_frame_id == params_.map_frame_id)
+  if ((!params_.invert_tf && params_.world_frame_id == params_.map_frame_id) || params_.publish_delta_information)
   {
     tf_buffer_ = std::make_unique<tf2_ros::Buffer>(
         clock_, params_.tf_cache_time.to_chrono<std::chrono::nanoseconds>()
@@ -107,6 +108,16 @@ void Odometry2DPublisher::onInit()
       rclcpp::create_publisher<nav_msgs::msg::Odometry>(interfaces_, params_.topic, params_.queue_size, pub_options);
   acceleration_pub_ = rclcpp::create_publisher<geometry_msgs::msg::AccelWithCovarianceStamped>(
       interfaces_, params_.acceleration_topic, params_.queue_size, pub_options);
+
+  if (params_.publish_delta_information)
+  {
+    delta_x_publisher_ = rclcpp::create_publisher<std_msgs::msg::Float64>(
+      interfaces_, params_.delta_x_topic, params_.queue_size, pub_options);
+    delta_y_publisher_ = rclcpp::create_publisher<std_msgs::msg::Float64>(
+      interfaces_, params_.delta_y_topic, params_.queue_size, pub_options);
+    delta_yaw_publisher_ = rclcpp::create_publisher<std_msgs::msg::Float64>(
+      interfaces_, params_.delta_yaw_topic, params_.queue_size, pub_options);
+  }
 }
 
 void Odometry2DPublisher::notifyCallback(fuse_core::Transaction::ConstSharedPtr transaction,
@@ -506,6 +517,33 @@ void Odometry2DPublisher::publishTimerCallback()
 
   if (params_.publish_tf)
   {
+    if (params_.publish_delta_information)
+    {
+      try
+      {
+        const auto odom_to_base = tf_buffer_->lookupTransform(params_.odom_frame_id, params_.base_link_frame_id,
+                                                              transformation_time, params_.tf_timeout);
+
+        const auto delta_x = odom_output.pose.pose.position.x - odom_to_base.transform.translation.x;
+        const auto delta_y = odom_output.pose.pose.position.y - odom_to_base.transform.translation.y;
+        const auto new_yaw = tf2::getYaw(odom_output.pose.pose.orientation);
+        const auto original_yaw = tf2::getYaw(odom_to_base.transform.rotation);
+        const auto delta_yaw = angles::shortest_angular_distance(new_yaw, original_yaw);
+        publishDouble(delta_x, delta_x_publisher_);
+        publishDouble(delta_y, delta_y_publisher_);
+        publishDouble(delta_yaw, delta_yaw_publisher_);
+      }
+      catch (std::exception const& e)
+      {
+        RCLCPP_WARN_STREAM_THROTTLE(logger_, *clock_, 5.0 * 1000,
+                                    "Could not lookup the " << params_.base_link_frame_id << "->"
+                                                            << params_.odom_frame_id
+                                                            << " transform. Error: " << e.what());
+
+        return;
+      }
+    }
+
     auto frame_id = odom_output.header.frame_id;
     auto child_frame_id = odom_output.child_frame_id;
 
@@ -551,6 +589,20 @@ void Odometry2DPublisher::publishTimerCallback()
     trans.header.stamp = transformation_time + rclcpp::Duration::from_seconds(params_.transform_tolerance);
     tf_broadcaster_->sendTransform(trans);
   }
+}
+
+void Odometry2DPublisher::publishDouble(double value,
+  const rclcpp::Publisher<std_msgs::msg::Float64>::SharedPtr& pub_to_use)
+{
+  if (!pub_to_use)
+  {
+    return;
+  }
+
+  std_msgs::msg::Float64 duration_msg;
+  duration_msg.data = value;
+
+  pub_to_use->publish(duration_msg);
 }
 
 }  // namespace fuse_models


### PR DESCRIPTION
Allow to publish the correction calculated by fuse to be published as delta topics